### PR TITLE
accept literal or boolean for args.minus_log

### DIFF
--- a/src/streamtomocupy/proc.py
+++ b/src/streamtomocupy/proc.py
@@ -43,7 +43,7 @@ class Proc:
         """Taking negative logarithm"""
         args = self.args
 
-        if args.minus_log == "True":
+        if args.minus_log == "True" or args.minus_log is True:
             # the following python code makes device synchronization,
             # see warning in https://docs.cupy.dev/en/stable/reference/generated/cupy.place.html
             # and https://github.com/cupy/cupy/blob/118ade4a146d1cc68519f7f661f2c145f0b942c9/cupy/_indexing/insert.py#L35


### PR DESCRIPTION
It would be great if minus_log was to accept a boolean and not just the string "True".

We weren't getting the right contrast for a while until I discovered this...